### PR TITLE
US003 - Eu, Valéria, desejo utilizar o norm_diff na interface web para que eu consiga ver a diferenca entre release planejada e realizada

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ const aliases = require('./settings/alias').reduce((acc, alias) => {
 
 module.exports = {
   roots: ['<rootDir>/src'],
-  collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}'],
+  collectCoverageFrom: ['app/**/*.{js,jsx,ts,tsx}', '!**/messages.ts'],
   testRegex: '((\\.|/*.)(spec))\\.tsx?$',
   coverageDirectory: 'coverage',
   preset: 'ts-jest',

--- a/src/pages/products/[product]/releases/[release]/components/CurveGraph/CurveGraph.tsx
+++ b/src/pages/products/[product]/releases/[release]/components/CurveGraph/CurveGraph.tsx
@@ -1,14 +1,18 @@
 import { LineChart } from '@mui/x-charts';
 import { Characteristic } from '@customTypes/product';
 import { useEffect, useState } from 'react';
-import { Box } from '@mui/material';
+import { Box, Card, CardContent, Divider, Tooltip, Typography } from '@mui/material';
+import { Stack } from '@mui/system';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import messages from './messages';
 
 export interface CurveGraphProps {
   planejado: Characteristic[];
   realizado: Characteristic[];
+  normDiff?: number;
 }
 
-export default function SimpleLineChart({ planejado, realizado }: CurveGraphProps) {
+export default function SimpleLineChart({ planejado, realizado, normDiff }: CurveGraphProps) {
   const [labels, setLabels] = useState<string[]>([]);
   const [planned, setPlanned] = useState<number[]>([]);
   const [accomplished, setAccomplihsed] = useState<number[]>([]);
@@ -45,35 +49,59 @@ export default function SimpleLineChart({ planejado, realizado }: CurveGraphProp
   if (planned.length !== accomplished.length) {
     return (
       <div>
-        <p>O número do resultados das caracteristicas planejadas deve ser igual ao número de realizadas</p>
+        <p>{messages.plannedAndAccomplishedDifferentSize}</p>
       </div>
     );
   }
+
+  const renderNormDiff = () =>
+    <>
+      <Divider />
+      <Box display="flex" justifyContent='space-between' mt={2} p={1}>
+        <Box display="flex" alignItems='center' >
+          <Typography mr={1}>
+            {messages.normDiff}
+          </Typography>
+          <Tooltip title={messages.normDiffExplanation} >
+            <InfoOutlinedIcon fontSize='small' />
+          </Tooltip>
+        </Box>
+        {normDiff?.toFixed(2)}
+      </Box>
+    </>
 
   return (
     <Box
       display="flex"
       alignItems="center"
+      mt={2}
       data-testid="line-chart">
-      <LineChart
-        width={700}
-        height={400}
-        series={series}
-        xAxis={[{
-          scaleType: 'point',
-          data: labels,
-          min: 0.0,
-          max: 1,
-          tickMinStep: 0,
-        }]}
-        yAxis={[
-          {
-            scaleType: 'linear',
-            min: 0.0,
-            max: 1,
-          },
-        ]}
-      />
+      <Card>
+        <CardContent>
+          <Stack>
+            <LineChart
+              width={700}
+              height={400}
+              series={series}
+              xAxis={[{
+                scaleType: 'point',
+                data: labels,
+                min: 0.0,
+                max: 1,
+                tickMinStep: 0,
+              }]}
+              yAxis={[
+                {
+                  scaleType: 'linear',
+                  min: 0.0,
+                  max: 1,
+                },
+              ]}
+            />
+            {normDiff && renderNormDiff()}
+          </Stack>
+        </CardContent>
+      </Card>
     </Box>
   );
 }

--- a/src/pages/products/[product]/releases/[release]/components/CurveGraph/messages.ts
+++ b/src/pages/products/[product]/releases/[release]/components/CurveGraph/messages.ts
@@ -1,0 +1,9 @@
+const messages = {
+  plannedAndAccomplishedDifferentSize:
+    'O número do resultados das caracteristicas planejadas deve ser igual ao número de realizadas',
+  normDiff: 'Diferença normalizada',
+  normDiffExplanation:
+    'Transformação vetorial entre a release planejada e a release realizada. Esta transformação representa a diferença quantitativa entre os requisitos de qualidade planejados e os os resultados observados após o desenvolvimento.'
+};
+
+export default messages;

--- a/src/pages/products/[product]/releases/[release]/index.page.tsx
+++ b/src/pages/products/[product]/releases/[release]/index.page.tsx
@@ -34,7 +34,7 @@ const Release: any = () => {
         setRelease(res.data.release);
       });
     }
-  }, [router.isReady]);
+  }, [router.isReady, routerParams.product, routerParams.release]);
 
 
   return (
@@ -65,7 +65,7 @@ const Release: any = () => {
               <Typography fontSize="24px" fontWeight="400">
                 {repositorio.repository_name}
               </Typography>
-              <SimpleLineChart planejado={planejado} realizado={repositorio.characteristics} />
+              <SimpleLineChart planejado={planejado} realizado={repositorio.characteristics} normDiff={repositorio.norm_diff} />
             </Styles.ContainerGraph>
           ))
         }

--- a/src/shared/customTypes/product.ts
+++ b/src/shared/customTypes/product.ts
@@ -214,6 +214,7 @@ export interface Characteristic {
 export interface AccomplishedRepository {
   repository_name: string;
   characteristics: Characteristic[];
+  norm_diff?: number;
 }
 
 export interface IReleasesWithGoalAndAccomplished {


### PR DESCRIPTION
## Motivação

<!-- In the motivation section, you need to explain around what has behind these changes, like a purpose of changes and what benefits do we get -->

## Mudanças

<!-- In the changelog section, you can add the changes in an objective way -->

Um novo campo, contando o norm_diff, foi adicionado no retorno do endpoint de análise entre release planejada e release desenvolvida. Portanto, o front foi adaptado para receber esse campo e apresentar junto ao gráfico de comparação de release planejada e desenvolvida.

## Status Checklist

<!-- In the status section, you can mark what you have already done -->

- [ ] Test
- [x] Lint
- [x] Development

## Screenshots

<!-- If you are adding a layout change, you can show the images below -->

| Before                                               | After                                                |
| ---------------------------------------------------- | ---------------------------------------------------- |
| ![image](https://github.com/user-attachments/assets/d0f98866-7d16-4cc9-b284-c9d3cbf54b40) | ![image](https://github.com/user-attachments/assets/0bd11ab3-c645-4e6f-8802-9b2fb161ade8) |

## Execução

<!-- How do we test the implementation? -->

- Acesse a página de comparação de release
