### PR TITLE
Ajuste na importação de repositórios

### DIFF
--- a/src/shared/services/Auth/index.tsx
+++ b/src/shared/services/Auth/index.tsx
@@ -72,4 +72,4 @@ export const getGithubAuthUrl = () =>
 
 
 export const getGithubAuthUrlToRepositoriesPage = (pathName: string) =>
-  `https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}&redirect_uri=${process.env.LOGIN_REDIRECT_URL}${pathName}`;
+  `https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}&redirect_uri=${process.env.LOGIN_REDIRECT_URL}${pathName}&prompt=select_account`;


### PR DESCRIPTION
Alterando URL para que a conta do github seja selecionada toda vez que o usuário tente importar o repositório